### PR TITLE
Fix undefined parent_edge_color when drawing edges from TC/CFC nodes

### DIFF
--- a/process.php
+++ b/process.php
@@ -253,6 +253,7 @@ function dpp_follow_destinations (&$route, $destination, $optional, $options) {
 	$stop=false; //reset on new call
 
 	if (!isset($route['parent_edge_code'])){$route['parent_edge_code']='';}
+	if (!isset($route['parent_edge_color'])){$route['parent_edge_color']='#000';}
 
 	if ($minimal){
 		$patterns = array(


### PR DESCRIPTION
## Summary
Fixes an `Undefined array key "parent_edge_color"` error in `process.php` that occurs when the parent node is a Time Condition (TC) or Call Flow Control (CFC).

## Problem
In `dpp_follow_destinations`, the edge color is set using `$route['parent_edge_color']` at line ~583, but the key is only assigned inside the `$containsEdgecase === false` branch. When the parent node label contains `"TC"` or `"Call Flow Control"`, `$containsEdgecase` is `true`, the assignment is skipped, and PHP raises a notice/error.

## Fix
Initialize `$route['parent_edge_color']` with the default edge color (`#000`) at the start of the function, consistent with the existing `parent_edge_code` initialization.

```php
if (!isset($route['parent_edge_code'])){$route['parent_edge_code']='';}
if (!isset($route['parent_edge_color'])){$route['parent_edge_color']='#000';}
```

## Testing
Reproduced the issue on a route containing a Time Condition followed by an extension.
Applied the patch and confirmed the graph renders without the 500 error.
Verified that regular edges still render in black (#000) and TC/CFC edges still receive the thicker penwidth.

## Related Issue

Closes #44 